### PR TITLE
Flutter 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## May 29, 2022
+
+- Validate for Flutter 3.0.1
+- Upgrade packages
+- Add redirect URLs to environment variables, so everything can be set in environment.dart
+- Refactor auth.dart and oauth.js to use current URL for web support without explicit configuration
+- Update with a quickstart for Google login, fixing [#39](https://github.com/gregertw/actingweb_firstapp/issues/39)
+- Bump version to 1.6.3+18
+
 ## Feb 18, 2022
 
 - Validate for Flutter 2.10.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Listed on: [![Awesome Flutter](https://img.shields.io/badge/Awesome-Flutter-blue
 
 **Latest build and artifacts**: [![Codemagic build status](https://api.codemagic.io/apps/5e23f3b4c5faa6a356815277/5e23f3b4c5faa6a356815276/status_badge.svg)](https://codemagic.io/apps/5e23f3b4c5faa6a356815277/5e23f3b4c5faa6a356815276/latest_build)
 
-**Latest update:** Support for Flutter 2.10.1
+**Latest update:** Support for Flutter 3.0.1
 
 There are lots of simple Flutter app examples out there, but very few show how to tie together the elements
 you need to put an app into production. In my process of evaluating Flutter maturity and readiness for
@@ -61,6 +61,39 @@ a production app point of view. Here are some possible improvements:
 ## CHANGELOG
 
 See CHANGELOG.md
+
+## QUICKSTART
+
+The easiest way to get started with this app is to get it running in your own browser locally. To do that, you need to
+configure a Google OAuth2 application at <https://console.cloud.google.com/apis/credentials>. You need to define
+your own application so you can use Google to log in, and you need to make sure that the app knows about the URL it is
+running from (i.e. localhost:port), so that it can present the URL to Google and the Google app is configured with the
+same URL as an allowed redirect URL. In addition, the app needs to present the secret for the Google app you have configured.
+If there is a mismatch in the URL your app is running under, what is configured in the app, and what is configured for the
+Google app, the login process will fail.
+
+Here are the steps:
+
+- Go to Google console as above and create a new OAuth client ID. Choose Web Application as type.
+- Add an Authorized redirect URI to <http://localhost:50000/>
+- Copy the client id and update `clientIdGoogleApp` in lib/environment.dart
+- Copy the client secret and `secretGoogleWeb`in the same file
+- Start debugging with: `flutter run --debug --web-port=50000` (this will allow the app to present the right redirect URL)
+
+In Visual Studio Code, you can add an entry to launch.json in .vscode:
+
+```json
+{
+            "name": "Flutter: Debug web",
+            "type": "dart",
+            "request": "launch",
+            "args": [
+                "--web-port=50000"
+            ],
+            "flutterMode": "debug",
+            "program": "lib/main.dart"
+        },
+```
 
 ## How to get started
 
@@ -167,7 +200,7 @@ Firebase Messaging initialisation.
 
 If you are doing debugging of the app on web, use Google login, you need to edit environment.dart with the client id
 and secret, and then (for local debugging) edit auth.dart and oauth.js with the localhost redirect URL with port number.
-In addition, Google web app (credentials) also need the ```http://localhost:<portnumber>/``` configured as a legal redirect URL.
+In addition, the Google web app (credentials) also need the ```http://localhost:<portnumber>/``` configured as a legal redirect URL. Configure Google web app at <https://console.cloud.google.com/apis/credentials>.
 
 **Note on Github!** Github only supports clientid and secret, and does explicitly not support retrieving an access token
 from a web applications (it is blocked with no CORS headers). This is because it is not considered safe. This means that

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,34 +1,34 @@
 PODS:
-  - Firebase/Analytics (8.11.0):
+  - Firebase/Analytics (8.15.0):
     - Firebase/Core
-  - Firebase/Core (8.11.0):
+  - Firebase/Core (8.15.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.11.0)
-  - Firebase/CoreOnly (8.11.0):
-    - FirebaseCore (= 8.11.0)
-  - Firebase/Crashlytics (8.11.0):
+    - FirebaseAnalytics (~> 8.15.0)
+  - Firebase/CoreOnly (8.15.0):
+    - FirebaseCore (= 8.15.0)
+  - Firebase/Crashlytics (8.15.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.11.0)
-  - Firebase/Messaging (8.11.0):
+    - FirebaseCrashlytics (~> 8.15.0)
+  - Firebase/Messaging (8.15.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.11.0)
-  - firebase_analytics (9.1.0):
-    - Firebase/Analytics (= 8.11.0)
+    - FirebaseMessaging (~> 8.15.0)
+  - firebase_analytics (9.1.9):
+    - Firebase/Analytics (= 8.15.0)
     - firebase_core
     - Flutter
-  - firebase_core (1.12.0):
-    - Firebase/CoreOnly (= 8.11.0)
+  - firebase_core (1.17.1):
+    - Firebase/CoreOnly (= 8.15.0)
     - Flutter
-  - firebase_crashlytics (2.5.0):
-    - Firebase/Crashlytics (= 8.11.0)
+  - firebase_crashlytics (2.8.1):
+    - Firebase/Crashlytics (= 8.15.0)
     - firebase_core
     - Flutter
-  - firebase_messaging (11.2.6):
-    - Firebase/Messaging (= 8.11.0)
+  - firebase_messaging (11.4.1):
+    - Firebase/Messaging (= 8.15.0)
     - firebase_core
     - Flutter
-  - FirebaseAnalytics (8.11.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.11.0)
+  - FirebaseAnalytics (8.15.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.15.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
@@ -36,37 +36,37 @@ PODS:
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.11.0):
+  - FirebaseAnalytics/AdIdSupport (8.15.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.11.0)
+    - GoogleAppMeasurement (= 8.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - FirebaseCore (8.11.0):
+  - FirebaseCore (8.15.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (8.11.0):
+  - FirebaseCoreDiagnostics (8.15.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.11.0):
+  - FirebaseCrashlytics (8.15.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseInstallations (8.11.0):
+  - FirebaseInstallations (8.15.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.11.0):
+  - FirebaseMessaging (8.15.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
@@ -78,7 +78,7 @@ PODS:
   - Flutter (1.0.0)
   - flutter_secure_storage (3.3.1):
     - Flutter
-  - flutter_web_auth (0.4.0):
+  - flutter_web_auth (0.4.1):
     - Flutter
   - geocoding (1.0.5):
     - Flutter
@@ -87,34 +87,34 @@ PODS:
   - google_maps_flutter (0.0.1):
     - Flutter
     - GoogleMaps
-  - GoogleAppMeasurement (8.11.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.11.0)
+  - GoogleAppMeasurement (8.15.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.11.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.11.0)
+  - GoogleAppMeasurement/AdIdSupport (8.15.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.11.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.15.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleDataTransport (9.1.2):
-    - GoogleUtilities/Environment (~> 7.2)
-    - nanopb (~> 2.30908.0)
+  - GoogleDataTransport (9.1.4):
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleMaps (6.0.1):
-    - GoogleMaps/Maps (= 6.0.1)
-  - GoogleMaps/Base (6.0.1)
-  - GoogleMaps/Maps (6.0.1):
+  - GoogleMaps (6.2.1):
+    - GoogleMaps/Maps (= 6.2.1)
+  - GoogleMaps/Base (6.2.1)
+  - GoogleMaps/Maps (6.2.1):
     - GoogleMaps/Base
   - GoogleUtilities/AppDelegateSwizzler (7.7.0):
     - GoogleUtilities/Environment
@@ -142,7 +142,7 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - PromisesObjC (2.0.0)
+  - PromisesObjC (2.1.0)
   - shared_preferences_ios (0.0.1):
     - Flutter
 
@@ -203,31 +203,31 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
 
 SPEC CHECKSUMS:
-  Firebase: 44dd9724c84df18b486639e874f31436eaa9a20c
-  firebase_analytics: b267e923ba3cdc892bdcadc01efab50f3b8b7441
-  firebase_core: 443bccfd6aa6b42f07be365b500773dc69db2d87
-  firebase_crashlytics: 824c5100677bbc8dbc4cc2b264dab21c0ffa3279
-  firebase_messaging: 8dc3a6f069774a0bf4dac04dd79fdaffcb62e145
-  FirebaseAnalytics: 4e4b13031034e6561ed3bd1d47b6fdabbd6487c6
-  FirebaseCore: 2f4f85b453cc8fea4bb2b37e370007d2bcafe3f0
-  FirebaseCoreDiagnostics: 64d9709d804a6c25bd77841371c1fcfd909d5601
-  FirebaseCrashlytics: 62268addefae79601057818156e8bc69d71fee41
-  FirebaseInstallations: 044eede8a049bce71c4541ee68d6e4364fcbe774
-  FirebaseMessaging: 02e248e8997f71fa8cc9d78e9d49ec1a701ba14a
+  Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
+  firebase_analytics: 99eefffcacf3ab694db7926dd1291833e1300853
+  firebase_core: 318de541b0e61d3f24262982a3f0b54afe72439b
+  firebase_crashlytics: 3ccd7b4f26a7fc546774b1074d2d10b0c6f92ab6
+  firebase_messaging: 943cfe65e0b3f457240489ce67655e40da1d270c
+  FirebaseAnalytics: 7761cbadb00a717d8d0939363eb46041526474fa
+  FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
+  FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
+  FirebaseCrashlytics: feb07e4e9187be3c23c6a846cce4824e5ce2dd0b
+  FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
+  FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
-  flutter_web_auth: fd071763f61703882adbb2524f5cd5251883118c
+  flutter_web_auth: 09a0abd245f1a07a3ff4dcf1247a048d89ee12a9
   geocoding: 32cfcdb16d38d907caaba65e2e42ad10d38bee58
-  geolocator_apple: b741765c55dc21950e3e106e8b3584e55cf81ce5
-  google_maps_flutter: abdb8dee6c52d4be36ad131ee6ebfacd14417c5a
-  GoogleAppMeasurement: aa3cb422fab2b05d2efac543a5720d1a85b9dea5
-  GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
-  GoogleMaps: c213fc2334b7374144cede914da779b99be0ab74
+  geolocator_apple: cc556e6844d508c95df1e87e3ea6fa4e58c50401
+  google_maps_flutter: c59fc576c0d0c7f4dc4bd63832c862d22d5a7c6d
+  GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
+  GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
+  GoogleMaps: 20d7b12be49a14287f797e88e0e31bc4156aaeb4
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
-  shared_preferences_ios: aef470a42dc4675a1cdd50e3158b42e3d1232b32
+  PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
+  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -65,5 +65,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/environment.dart
+++ b/lib/environment.dart
@@ -6,21 +6,38 @@ class Environment {
           "BCKRpKeIZ7-0iWQGbOe6rcTGW1kvAGbyDNPH4Waw-Yzs2cRPJ5xsKUvoybBp2l7KIBx7W2SYh1T9kKh3dlG2KHw");
   // Default values here are client ids for the test version of first_app
   // in app stores and on the web.
+  static const String customUriScheme = String.fromEnvironment(
+      "CUSTOM_URI_SCHEME",
+      defaultValue: "io.actingweb.firstapp");
+
+  static const String redirectUrlGithubApp = String.fromEnvironment(
+      "REDIRECTURL_GITHUB_APP",
+      defaultValue: "io.actingweb.firstapp://oauthredirect");
   static const String clientIdGithubApp = String.fromEnvironment(
       "CLIENTID_GITHUB_APP",
       defaultValue: "b304cfeaaf2710cf250a");
   static const String secretGithubApp =
       String.fromEnvironment("SECRET_GITHUB_APP", defaultValue: "");
 
+  static const String redirctUrlGoogleApp = String.fromEnvironment(
+      "REDIRECTURL_GOOGLE_APP",
+      // This value needs to be changed when you change the CUSTOM_URI_SCHEME and app scheme in
+      defaultValue: "io.actingweb.firstapp:/oauthredirect");
   static const String clientIdGoogleApp = String.fromEnvironment(
       "CLIENTID_GOOGLE_APP",
       defaultValue:
           "748007732162-nnqg752ptfoejjmfg8bfo244j1bs2v71.apps.googleusercontent.com");
 
+  static const String redirctUrlGoogleWeb =
+      // If value is empty, the current URL path will be used, which normally works ok so this
+      // value doesn't have to be explicitly set.
+      String.fromEnvironment("REDIRECTURL_GOOGLE_WEB", defaultValue: '');
   static const String clientIdGoogleWeb = String.fromEnvironment(
       "CLIENTID_GOOGLE_WEB",
+      // The default value here is for illustration purposes only.
       defaultValue:
           "748007732162-5h639jbt5m5tnjf675c7b0h13r8ajomg.apps.googleusercontent.com");
-  static const String secretGoogleWeb =
-      String.fromEnvironment("SECRET_GOOGLE_WEB", defaultValue: "");
+  static const String secretGoogleWeb = String.fromEnvironment(
+      "SECRET_GOOGLE_WEB",
+      defaultValue: "MUST_BE_SET_FROM_GOOGLE_OAUTH_CLIENT");
 }

--- a/lib/generated_plugin_registrant.dart
+++ b/lib/generated_plugin_registrant.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: depend_on_referenced_packages
 
 import 'package:firebase_analytics_web/firebase_analytics_web.dart';
 import 'package:firebase_core_web/firebase_core_web.dart';

--- a/lib/models/appstate.dart
+++ b/lib/models/appstate.dart
@@ -103,7 +103,7 @@ class AppStateModel with ChangeNotifier {
         String? str;
         // ignore: avoid_print
         print('Message also contained a notification: ${message.notification}');
-        str = message.notification!.title! + ' ' + message.notification!.body!;
+        str = '${message.notification!.title!} ${message.notification!.body!}';
         lastNotificationTitle =
             message.notification!.title ?? 'No title in notication';
         lastNotificationBody =
@@ -146,20 +146,20 @@ class AppStateModel with ChangeNotifier {
 
   /// Rotates through the supported locales.
   void switchLocale() {
-    const _locales = AppLocalizations.supportedLocales;
-    if (_locales.length == 1) {
+    const locales = AppLocalizations.supportedLocales;
+    if (locales.length == 1) {
       return;
     }
     int ind = 0;
-    _locales.asMap().forEach((key, value) {
+    locales.asMap().forEach((key, value) {
       if (value.languageCode == _locale) {
         ind = key + 1;
       }
     });
-    if (ind >= _locales.length) {
+    if (ind >= locales.length) {
       ind = 0;
     }
-    setLocale(_locales[ind].languageCode);
+    setLocale(locales[ind].languageCode);
   }
 
   /// Sends off a Firebase Analytics event.

--- a/lib/providers/auth.dart
+++ b/lib/providers/auth.dart
@@ -100,15 +100,17 @@ class AuthClient {
   String? provider;
   // For Android and iOS, this must match the URI in the [_redirectUrls].
   // Must be the same as the Android applicationId and iOS bundle scheme.
-  static const String _customUriScheme = 'io.actingweb.firstapp';
-  static const Map<String, String> _redirectUrls = {
+  static const String _customUriScheme = Environment.customUriScheme;
+  static final Map<String, String> _redirectUrls = {
     'mock': 'localhost',
-    'github': 'io.actingweb.firstapp://oauthredirect',
-    'github_web': 'https://gregertw.github.io/actingweb_firstapp_web/',
-    'google': 'io.actingweb.firstapp:/oauthredirect',
-    // Edit the port number below to debug locally, also oauth.js needs to be edited
-    //'google_web': 'http://localhost:56906/'
-    'google_web': 'https://gregertw.github.io/actingweb_firstapp_web/'
+    'github': Environment.clientIdGithubApp,
+    'github_web': 'NOT_SUPPORTED',
+    'google': Environment.clientIdGoogleApp,
+    'google_web': Environment.redirctUrlGoogleWeb == ''
+        ? Uri.base
+            .toString()
+            .split('#/')[0] // Get the current full URL without trailing #/
+        : Environment.redirctUrlGoogleWeb
   };
   static const Map<String, List<String>> _scopes = {
     'github': <String>[],

--- a/lib/providers/auth.dart
+++ b/lib/providers/auth.dart
@@ -52,7 +52,7 @@ class AuthUserInfo {
         avatarUrl ??= info['picture'];
         break;
       default:
-        throw 'Does not know how to parse AuthUserInfo from ' + provider;
+        throw 'Does not know how to parse AuthUserInfo from $provider';
     }
   }
 }
@@ -182,7 +182,7 @@ class AuthClient {
   /// Configure/override the identity provider settings.
   void setPresetIdentityProvider(String provider) {
     if (web && !provider.contains('_web')) {
-      provider = provider + '_web';
+      provider = '${provider}_web';
     }
     if (!_redirectUrls.containsKey(provider)) {
       throw 'No provider set and authProvider not supplied.';
@@ -203,7 +203,7 @@ class AuthClient {
         clientSecret = Environment.secretGithubApp;
         break;
       case 'github_web':
-        // Github web is not supported
+        // Github web is not supported from Github
         authProvider = GitHubOAuth2Client(
             redirectUri: redirectUrl!, customUriScheme: customUriScheme!);
         clientId = '';

--- a/lib/ui/pages/home/drawer.dart
+++ b/lib/ui/pages/home/drawer.dart
@@ -30,9 +30,8 @@ class HomePageDrawer extends StatelessWidget {
                 Text(AppLocalizations.of(context)!.drawerGetLastNotification),
             onTap: () {
               ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                content: Text((appState.lastNotificationTitle ?? 'N/A') +
-                    ': ' +
-                    (appState.lastNotificationBody ?? 'N/A')),
+                content: Text(
+                    '${appState.lastNotificationTitle ?? 'N/A'}: ${appState.lastNotificationBody ?? 'N/A'}'),
                 duration: const Duration(seconds: 5),
               ));
               Navigator.of(context).pop();
@@ -207,8 +206,8 @@ Widget buildDrawerHeader(BuildContext context) {
       },
     ),
     currentAccountPicture: CircleAvatar(
-      child: Image.asset('assets/actingweb-header-small.png'),
       backgroundColor: Colors.white,
+      child: Image.asset('assets/actingweb-header-small.png'),
     ),
   );
 }

--- a/lib/ui/pages/login/index.dart
+++ b/lib/ui/pages/login/index.dart
@@ -26,13 +26,13 @@ class LoginPage extends StatelessWidget {
     Column body;
     if (appState.authenticated) {
       body = Column(
-        children: [logo, welcome],
         mainAxisAlignment: MainAxisAlignment.center,
+        children: [logo, welcome],
       );
     } else {
       body = Column(
-        children: [logo, welcome, const AuthPage()],
         mainAxisAlignment: MainAxisAlignment.center,
+        children: [logo, welcome, const AuthPage()],
       );
     }
     return Scaffold(

--- a/lib/ui/pages/map/index.dart
+++ b/lib/ui/pages/map/index.dart
@@ -9,10 +9,10 @@ class OverlayMapPage extends StatefulWidget {
   const OverlayMapPage({Key? key}) : super(key: key);
 
   @override
-  _OverlayMapPageState createState() => _OverlayMapPageState();
+  OverlayMapPageState createState() => OverlayMapPageState();
 }
 
-class _OverlayMapPageState extends State<OverlayMapPage> {
+class OverlayMapPageState extends State<OverlayMapPage> {
   final Completer<GoogleMapController> _controller = Completer();
   Set<Marker>? _markers;
   // If you want to record the position when the user moves the map, see the GoogleMap widget below

--- a/lib/ui/widgets/anchored_overlay.dart
+++ b/lib/ui/widgets/anchored_overlay.dart
@@ -45,10 +45,10 @@ class OverlayBuilder extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _OverlayBuilderState createState() => _OverlayBuilderState();
+  OverlayBuilderState createState() => OverlayBuilderState();
 }
 
-class _OverlayBuilderState extends State<OverlayBuilder> {
+class OverlayBuilderState extends State<OverlayBuilder> {
   OverlayEntry? overlayEntry;
 
   @override
@@ -56,22 +56,20 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
     super.initState();
 
     if (widget.showOverlay!) {
-      WidgetsBinding.instance!.addPostFrameCallback((_) => showOverlay());
+      WidgetsBinding.instance.addPostFrameCallback((_) => showOverlay());
     }
   }
 
   @override
   void didUpdateWidget(OverlayBuilder oldWidget) {
     super.didUpdateWidget(oldWidget);
-    WidgetsBinding.instance!
-        .addPostFrameCallback((_) => syncWidgetAndOverlay());
+    WidgetsBinding.instance.addPostFrameCallback((_) => syncWidgetAndOverlay());
   }
 
   @override
   void reassemble() {
     super.reassemble();
-    WidgetsBinding.instance!
-        .addPostFrameCallback((_) => syncWidgetAndOverlay());
+    WidgetsBinding.instance.addPostFrameCallback((_) => syncWidgetAndOverlay());
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ description: A Flutter starter app that gives you a solid foundation for a real 
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.6.2+17
+version: 1.6.3+18
 
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: first_app
-description: An application that manages and receives alerts from ActingWeb actors
+description: A Flutter starter app that gives you a solid foundation for a real app
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -21,30 +21,31 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: any
-  oauth2_client: ^2.3.2
+  oauth2_client: ^2.4.0
   cupertino_icons: ^1.0.3
   meta: ^1.7.0
-  provider: ^6.0.2
-  shared_preferences: ^2.0.13
-  google_maps_flutter: ^2.1.1
-  google_maps_flutter_web: ^0.3.2+1
-  geocoding: ^2.0.2
-  firebase_core: ^1.12.0
-  firebase_analytics: ^9.1.0
-  firebase_crashlytics: ^2.5.1
-  firebase_messaging: ^11.2.6
-  geolocator: ^8.2.0
+  http: ^0.13.4
+  provider: ^6.0.3
+  shared_preferences: ^2.0.15
+  google_maps_flutter: ^2.1.6
+  google_maps_flutter_web: ^0.3.3
+  geocoding: ^2.0.4
+  firebase_core: ^1.17.1
+  firebase_analytics: ^9.1.9
+  firebase_crashlytics: ^2.8.1
+  firebase_messaging: ^11.4.1
+  geolocator: ^8.2.1
+  mockito: ^5.2.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
-  test: ^1.19.5
+  flutter_lints: ^2.0.1
+  test: ^1.21.1
   flutter_launcher_icons: ^0.9.0
   convert: ^3.0.1
-  mockito: ^5.1.0
 
 flutter_icons:
   android: "launcher_icon"

--- a/web/oauth.js
+++ b/web/oauth.js
@@ -2,9 +2,7 @@ window.onload = function () {
     const urlParams = new URLSearchParams(window.location.search);
     const code = urlParams.get('code');
     if (code) {
-        // Edit the port number here for local debugging, also change the redirectUrl in the auth.dart file
-        // Also remember that the client in Google console needs to have the localhost URL registered!
-        //window.opener.postMessage(window.location.href, 'http://localhost:56906/');
-        window.opener.postMessage(window.location.href, 'https://gregertw.github.io/actingweb_firstapp_web/');
+        // Also, if debugging locally, remember that the client in Google console needs to have the localhost URL registered!
+        window.opener.postMessage(window.location.href, window.location.href);
     }
-}
+}   


### PR DESCRIPTION
- Validate for Flutter 3.0.1
- Upgrade packages
- Add redirect URLs to environment variables, so everything can be set in environment.dart
- Refactor auth.dart and oauth.js to use current URL for web support without explicit configuration
- Update with a quickstart for Google login, fixing [#39](https://github.com/gregertw/actingweb_firstapp/issues/39)
- Bump version to 1.6.3+18